### PR TITLE
Add logging for handler errors.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const fs = require('fs');
 const http = require('http');
 const path = require('path');
@@ -164,6 +166,20 @@ function appy(opts) {
                 try {
                     _handleResponse(route.handler(req, matches, responder, res));
                 } catch (e) {
+                    let message, stack;
+
+                    if (e instanceof Error) {
+                        message = e.message;
+                        let lines = e.stack.split('\n');
+                        let internalLineIndex = lines.findIndex(line => line.match(/_dispatch.*\/appy-bird\/index.js/));
+                        stack = lines.slice(1, internalLineIndex + 1).join('\n');
+                    } else {
+                        message = e;
+                    }
+
+                    console.error(`Error in handler for ${route.path}: ${message}`);
+                    if (stack) { console.error(stack); }
+
                     _handleError(e);
                 }
             }


### PR DESCRIPTION
Not 100% on the implementation here, so let me know what you think.

Basically, the first thing I ran into when trying to use appy-bird, was opaque 500 errors when I had done something dumb (making un-serializable json objects for one).

So I added some simple console.error logging. Additionally I've trimmed the stack trace to avoid logging appy-bird internals, but maybe that's overkill? Trying to find the balance between flooding logs, and useful.

What do you think?
